### PR TITLE
DM-11507: Hard-code path to sed on Darwin (macOS).

### DIFF
--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -16,7 +16,7 @@ config()
 	esac
 
 	# Work around Darwin vs. GNU sed differences
-	[[ $(uname) = Darwin ]] && SED_INPLACE="sed -i '.prev'" || SED_INPLACE="sed -i"
+	[[ $(uname) = Darwin ]] && SED_INPLACE="/usr/bin/sed -i '.prev'" || SED_INPLACE="sed -i"
 
 	$SED_INPLACE "s/PLAT= none/PLAT= ${PLAT}/" Makefile &&
 	$SED_INPLACE "s,INSTALL_TOP= /usr/local,INSTALL_TOP= ${PREFIX}," Makefile &&


### PR DESCRIPTION
We know /usr/bin/sed will be the OS-provided version (thanks to SIP), but the
user's environment could contain an alternative. Prefer the former.