### PR TITLE
respect CC when being built by eupspkg

### DIFF
--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -1,4 +1,5 @@
 # EupsPkg config file. Sourced by 'eupspkg'
+# shellcheck shell=bash
 
 # Breaks on Darwin w/o this
 export LANG=C
@@ -22,5 +23,6 @@ config()
 	$SED_INPLACE "s,INSTALL_TOP= /usr/local,INSTALL_TOP= ${PREFIX}," Makefile &&
 	$SED_INPLACE "s,CFLAGS= -O2,CFLAGS= -I${PREFIX}/include -fPIC -O2," src/Makefile &&
 	$SED_INPLACE "s,LIBS= -lm,LIBS= -L${PREFIX}/lib -lm," src/Makefile &&
-	$SED_INPLACE "s,#define LUA_ROOT\t\"/usr/local/\",#define LUA_ROOT\t\"${PREFIX}/\"," src/luaconf.h
+	$SED_INPLACE "s,#define LUA_ROOT\t\"/usr/local/\",#define LUA_ROOT\t\"${PREFIX}/\"," src/luaconf.h &&
+	$SED_INPLACE 's/^CC.*/CC?=gcc/' src/Makefile etc/Makefile
 }


### PR DESCRIPTION
Lua has `CC= gcc` hard-coded in a couple of `Makefile`s.  In order to use `clang`, `make CC=clang ...` needs to be used.  Doing this under `eupspkg` would require overriding `build` in `eupspkg.cfg.sh` and duplicating the "TAP" functionality from the default version.  It seems slightly better from a maintainability perspective to modify the `Makefile`s rather than have to adapt  `eupspkg.cfg.sh` to future changes in `default_build()`.